### PR TITLE
add an encoding for OCaml ('a, 'b) result type

### DIFF
--- a/src/json_encoding.mli
+++ b/src/json_encoding.mli
@@ -163,6 +163,9 @@ val ranged_float : minimum:float -> maximum:float -> string -> float encoding
     of [null]. *)
 val option : 'a encoding -> 'a option encoding
 
+(** Same as above, but for an OCaml result value *)
+val result : 'a encoding -> 'b encoding -> ('a, 'b) result encoding
+
 (** {2 JSON type combinators for objects} *) (*********************************)
 
 (** A first class handle to a JSON field. *)


### PR DESCRIPTION
Similarly to OCaml type `'a option`, add a case to be able to encode / decode  `('a, 'b) result`