### PR TITLE
Revert "add an encoding for OCaml ('a, 'b) result type"

### DIFF
--- a/src/json_encoding.ml
+++ b/src/json_encoding.ml
@@ -57,7 +57,6 @@ type _ encoding =
   | Empty : unit encoding
   | Ignore : unit encoding
   | Option : 'a encoding -> 'a option encoding
-  | Result : 'a encoding * 'b encoding -> ('a, 'b) result encoding
   | Constant : string -> unit encoding
   | Int : 'a int_encoding -> 'a encoding
   | Bool : bool encoding
@@ -188,10 +187,7 @@ module Make (Repr : Json_repr.Repr) = struct
                  match proj v with
                  | Some v -> construct encoding v
                  | None -> do_cases rest in
-             do_cases cases)
-        | Result (ok, err) ->
-          (function Ok v -> construct ok v | Error v -> construct err v)
-    in
+             do_cases cases) in
     construct enc v
 
   let rec destruct
@@ -305,16 +301,6 @@ module Make (Repr : Json_repr.Repr) = struct
                try inj (destruct encoding v) with
                  err -> do_cases (err :: errs) rest in
            do_cases [] cases)
-
-      | Result (ok, err) ->
-        (fun v ->
-           try Ok (destruct ok v)
-           with err1 ->
-           try Error (destruct err v)
-           with err2 ->
-             raise (Cannot_destruct ([], No_case_matched [err1; err2]))
-        )
-
   and destruct_tup
     : type t. int -> t encoding -> (Repr.value array -> t) * int
     = fun i t -> match t with
@@ -547,10 +533,7 @@ let schema ?definitions_path encoding =
       | Union cases -> (* FIXME: smarter merge *)
         let elements =
           List.map (fun (Case { encoding }) -> schema encoding) cases in
-        element (Combine (One_of, elements))
-      | Result (ok, err) ->
-        element (Combine (One_of, [schema ok; schema err]))
-in
+        element (Combine (One_of, elements)) in
   let schema = schema encoding in
   update schema !sch
 
@@ -783,7 +766,6 @@ let rec is_nullable: type t. t encoding -> bool = function
   | Null -> true
   | Ignore -> true
   | Option _ -> true
-  | Result (a, b) -> is_nullable a || is_nullable b
   | Conv (_, _, t, _) -> is_nullable t
   | Union cases ->
     List.exists (fun (Case { encoding = t }) -> is_nullable t) cases
@@ -795,10 +777,6 @@ let option : type t. t encoding -> t option encoding = fun t ->
   if is_nullable t then
     invalid_arg "Json_encoding.option: cannot nest nullable encodings";
   Option t
-
-let result : type s t. s encoding -> t encoding -> (s, t) result encoding =
-  fun s t ->
-  Result (s, t)
 
 let any_value =
   let read repr v = Json_repr.repr_to_any repr v in

--- a/src/json_encoding.mli
+++ b/src/json_encoding.mli
@@ -163,9 +163,6 @@ val ranged_float : minimum:float -> maximum:float -> string -> float encoding
     of [null]. *)
 val option : 'a encoding -> 'a option encoding
 
-(** Same as above, but for an OCaml result value *)
-val result : 'a encoding -> 'b encoding -> ('a, 'b) result encoding
-
 (** {2 JSON type combinators for objects} *) (*********************************)
 
 (** A first class handle to a JSON field. *)


### PR DESCRIPTION
Reverts OCamlPro/ocplib-json-typed#27

This is a little bit confusing and may be a sources of bugs. It's better to define a type result on client side as a union with names for json fields