### PR TITLE
Add title & description to union `Case _`s

### DIFF
--- a/src/json_encoding.ml
+++ b/src/json_encoding.ml
@@ -112,6 +112,8 @@ and _ field =
 
 and 't case =
   | Case : { encoding : 'a encoding ;
+             title: string option ;
+             description: string option ;
              proj : ('t -> 'a option) ;
              inj : ('a -> 't) } -> 't case
 
@@ -532,7 +534,8 @@ let schema ?definitions_path encoding =
       | Tups _ as t -> element (Array (array_schema t, array_specs))
       | Union cases -> (* FIXME: smarter merge *)
         let elements =
-          List.map (fun (Case { encoding }) -> schema encoding) cases in
+          List.map (fun (Case { encoding; title; description}) ->
+              patch_description ?title ?description (schema encoding)) cases in
         element (Combine (One_of, elements)) in
   let schema = schema encoding in
   update schema !sch
@@ -845,8 +848,8 @@ let empty =
 let unit =
   Ignore
 
-let case encoding proj inj  =
-  Case { encoding ; proj ; inj }
+let case ?title ?description encoding proj inj  =
+  Case { encoding ; proj ; inj; title; description }
 
 let union = function
   | [] -> invalid_arg "Json_encoding.union"

--- a/src/json_encoding.mli
+++ b/src/json_encoding.mli
@@ -332,8 +332,11 @@ type 't case
 (** To be used inside a {!union}. Takes a [encoding] for a specific
     case, and a converter to and from a type common to all cases
     (['t]). Usually, it consists in boxing / deboxing the specific
-    data in an OCaml sum type contructor. *)
-val case : 'a encoding -> ('t -> 'a option) -> ('a -> 't) -> 't case
+    data in an OCaml sum type constructor. *)
+val case :
+  ?title:string ->
+  ?description:string ->
+  'a encoding -> ('b -> 'a option) -> ('a -> 'b) -> 'b case
 
 (** A utility to build destructors for custom encoded sum types. *)
 val union : 't case list -> 't encoding


### PR DESCRIPTION
The title and description then show up properly in generated schemas, e.g.:

```
      "oneOf": [
        {
          "title": "inline-markdown",
          "description": "Markdown prose as a string.",
          "type": "object",
          "properties": {
            "inline-markdown": {
              "$ref": "#/definitions/unistring"
            }
          },
          "required": [
            "inline-markdown"
          ],
          "additionalProperties": false
        },
        {
          "title": "external",
          "description": "URI referencing Markdown prose in another document.",
          "type": "object",
          "properties": {
            "external": {
              "$ref": "#/definitions/unistring"
            }
          },
          "required": [
            "external"
          ],
          "additionalProperties": false
        }
      ]
```