### PR TITLE
Add a dune-project file

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.7)
+(name ocplib-json-typed)


### PR DESCRIPTION
It seems that, if we _vendor_ `ocplib-json-typed` with several others projects (via `opam monorepo`), `dune` complains about a missing `dune-project` file. It will be nice to add it into the distribution to allow `ocplib-json-typed` to be vendored via `opam monorepo` and be able to compile then a project with `dune`.

I don't know details on the `dune` side but this PR fix the problem.