### PR TITLE
Add a basic dune-project file

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,3 @@
+(lang dune 1.0)
+
+(name ocplib-json-typed)


### PR DESCRIPTION
Having a `dune-project` file is important when trying to vendor all dependencies with `opam-monorepo`, the one I added is very basic and allows to vendor ocplib-json-typed.
Thanks!