### PR TITLE
Remove `build` flag from `dune` dependency

### DIFF
--- a/ocplib-json-typed-browser.opam
+++ b/ocplib-json-typed-browser.opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.7"}
+  "dune" {>= "1.7"}
   "ocplib-json-typed" {= "dev" }
   "js_of_ocaml" {>= "3.3.0"}
 ]

--- a/ocplib-json-typed-bson.opam
+++ b/ocplib-json-typed-bson.opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.7"}
-  "ocplib-json-typed" {= "dev" }
+  "dune" {>= "1.7"}
+  "ocplib-json-typed" {= version}
   "ocplib-endian" {>= "1.0"}
 ]

--- a/ocplib-json-typed.opam
+++ b/ocplib-json-typed.opam
@@ -15,6 +15,6 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.7"}
+  "dune" {>= "1.7"}
   "uri" {>= "1.9.0" }
 ]


### PR DESCRIPTION
opam-repository maintainers prefer the flag not to be there.

Also fixes a version constraint of the BSON file to depend on the exact same version as itself.